### PR TITLE
Add the Ability to Specify a Custom Target for Proxy Request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "foxy-io"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxy-io"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 authors = ["Johan Steffens <johan@steff.co.za>"]
 description = "A configuration-driven and hyper-extensible HTTP proxy library"

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -166,7 +166,7 @@ pub struct ProxyRequest {
     pub headers: reqwest::header::HeaderMap,
     pub body: reqwest::Body,
     pub context: Arc<RwLock<RequestContext>>,
-    pub custom_target: String,
+    pub custom_target: Option<String>,
 }
 
 impl Clone for ProxyRequest {
@@ -377,10 +377,10 @@ impl ProxyCore {
         crate::info!("Initial target: {}", route.target_base_url);
 
         /* ---------- build outbound req ---------- */
-        if(!request.custom_target.is_empty()){
-            crate::info!("Attempting to dynamically set target base Url from: {} to: {}", route.target_base_url, request.custom_target);
-            route.target_base_url = request.custom_target.clone();
-            crate::info!("Dynamically set target base Url to: {}", route.target_base_url);
+        if(request.custom_target.is_some()){
+            crate::debug!("Attempting to dynamically set target base Url: {}", route.target_base_url);
+            route.target_base_url = request.custom_target.clone().unwrap();
+            crate::debug!("Dynamically set target base Url to: {}", route.target_base_url);
         }
         
         let url = format!("{}{}", route.target_base_url, request.path);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -166,6 +166,7 @@ pub struct ProxyRequest {
     pub headers: reqwest::header::HeaderMap,
     pub body: reqwest::Body,
     pub context: Arc<RwLock<RequestContext>>,
+    pub target: String,
 }
 
 impl Clone for ProxyRequest {
@@ -178,6 +179,7 @@ impl Clone for ProxyRequest {
             headers:  self.headers.clone(),
             body:     reqwest::Body::from(""),
             context:  self.context.clone(),
+            target: self.target.clone(),
         }
     }
 }
@@ -339,7 +341,7 @@ impl ProxyCore {
                 }
             }
         }
-        
+
         let route = match self.router.route(&request).await {
             Ok(r) => {
                 crate::debug!("Request {} {} matched route: {}", method, path, r.id);
@@ -357,7 +359,7 @@ impl ProxyCore {
                 return Err(e);
             }
         };
-        
+
         let route_filters = route.filters.clone().unwrap_or_default();
         for f in &route_filters {
             if f.filter_type().is_pre() || f.filter_type().is_both() {
@@ -420,7 +422,7 @@ impl ProxyCore {
 
         let upstream_start = Instant::now();
         crate::trace!("Sending request to upstream with timeout: {:?}", timeout_duration);
-        
+
         let resp = match timeout(timeout_duration, builder.send()).await {
             Ok(result) => match result {
                 Ok(response) => response,
@@ -459,7 +461,7 @@ impl ProxyCore {
             ));
             client_span.end();
         }
-        
+
         let upstream_elapsed = upstream_start.elapsed();
         crate::trace!("Received response from upstream in {:?}", upstream_elapsed);
 
@@ -491,7 +493,7 @@ impl ProxyCore {
                 }
             }
         }
-        
+
         for f in self.global_filters.read().await.iter() {
             if f.filter_type().is_post() || f.filter_type().is_both() {
                 crate::trace!("Applying global post-filter: {}", f.name());
@@ -516,7 +518,7 @@ impl ProxyCore {
                 return Err(e);
             }
         };
-        
+
         /* ---------- timing log ---------- */
         let overall_elapsed = overall_start.elapsed();
         let internal_elapsed = overall_elapsed.saturating_sub(upstream_elapsed);

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        HttpMethod, ProxyRequest, ProxyResponse, 
+        HttpMethod, ProxyRequest, ProxyResponse,
         RequestContext, ResponseContext
     };
     use std::sync::Arc;
@@ -40,11 +40,11 @@ mod tests {
     #[test]
     fn test_request_context() {
         let mut context = RequestContext::default();
-        
+
         // Test attribute manipulation
         context.attributes.insert("key1".to_string(), serde_json::json!("value1"));
         context.attributes.insert("key2".to_string(), serde_json::json!(42));
-        
+
         assert_eq!(context.attributes.get("key1").unwrap(), &serde_json::json!("value1"));
         assert_eq!(context.attributes.get("key2").unwrap(), &serde_json::json!(42));
     }
@@ -52,11 +52,11 @@ mod tests {
     #[test]
     fn test_response_context() {
         let mut context = ResponseContext::default();
-        
+
         // Test attribute manipulation
         context.attributes.insert("key1".to_string(), serde_json::json!("value1"));
         context.attributes.insert("key2".to_string(), serde_json::json!(42));
-        
+
         assert_eq!(context.attributes.get("key1").unwrap(), &serde_json::json!("value1"));
         assert_eq!(context.attributes.get("key2").unwrap(), &serde_json::json!(42));
     }
@@ -71,14 +71,15 @@ mod tests {
             headers: reqwest::header::HeaderMap::new(),
             body: reqwest::Body::from(Vec::new()),
             context: context.clone(),
+            target: "http://test.co.za".to_string(),
         };
-        
+
         // Test context manipulation
         {
             let mut ctx = request.context.write().await;
             ctx.attributes.insert("test".to_string(), serde_json::json!("value"));
         }
-        
+
         let ctx = request.context.read().await;
         assert_eq!(ctx.attributes.get("test").unwrap(), &serde_json::json!("value"));
     }
@@ -92,13 +93,13 @@ mod tests {
             body: reqwest::Body::from(Vec::new()),
             context: context.clone(),
         };
-        
+
         // Test context manipulation
         {
             let mut ctx = response.context.write().await;
             ctx.attributes.insert("test".to_string(), serde_json::json!("value"));
         }
-        
+
         let ctx = response.context.read().await;
         assert_eq!(ctx.attributes.get("test").unwrap(), &serde_json::json!("value"));
     }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -71,7 +71,7 @@ mod tests {
             headers: reqwest::header::HeaderMap::new(),
             body: reqwest::Body::from(Vec::new()),
             context: context.clone(),
-            target: "http://test.co.za".to_string(),
+            custom_target: "http://test.co.za".to_string(),
         };
 
         // Test context manipulation

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -71,7 +71,7 @@ mod tests {
             headers: reqwest::header::HeaderMap::new(),
             body: reqwest::Body::from(Vec::new()),
             context: context.clone(),
-            custom_target: "http://test.co.za".to_string(),
+            custom_target: Option::Some("http://test.co.za".to_string()),
         };
 
         // Test context manipulation

--- a/src/filters/tests.rs
+++ b/src/filters/tests.rs
@@ -38,7 +38,7 @@ mod tests {
             headers: header_map,
             body: Body::from(body),
             context: Arc::new(RwLock::new(RequestContext::default())),
-            custom_target: target.to_string(),
+            custom_target: Some(target.to_string()),
         }
     }
 

--- a/src/filters/tests.rs
+++ b/src/filters/tests.rs
@@ -38,7 +38,7 @@ mod tests {
             headers: header_map,
             body: Body::from(body),
             context: Arc::new(RwLock::new(RequestContext::default())),
-            target: target.to_string(),
+            custom_target: target.to_string(),
         }
     }
 

--- a/src/router/tests.rs
+++ b/src/router/tests.rs
@@ -19,7 +19,7 @@ mod tests {
     use std::collections::HashMap;
 
     // Helper function to create a test request
-    fn create_test_request(method: HttpMethod, path: &str, query: Option<&str>, headers: Vec<(&'static str, &'static str)>) -> ProxyRequest {
+    fn create_test_request(method: HttpMethod, path: &str, query: Option<&str>, headers: Vec<(&'static str, &'static str)>, target: &str) -> ProxyRequest {
         let mut header_map = reqwest::header::HeaderMap::new();
         for (name, value) in headers {
             header_map.insert(
@@ -35,6 +35,7 @@ mod tests {
             headers: header_map,
             body: Body::from(Vec::new()),
             context: Arc::new(RwLock::new(RequestContext::default())),
+            target: target.to_string(),
         }
     }
 
@@ -46,17 +47,17 @@ mod tests {
         let predicate = PathPredicate::new(config).unwrap();
 
         // Test matching paths
-        let request = create_test_request(HttpMethod::Get, "/api/users", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api/users", None, vec![], "http://test.co.za");
         assert!(predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Get, "/api/products", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api/products", None, vec![], "http://test.co.za");
         assert!(predicate.matches(&request).await);
 
         // Test non-matching paths
-        let request = create_test_request(HttpMethod::Get, "/users", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/users", None, vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Get, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", None, vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
     }
 
@@ -68,17 +69,17 @@ mod tests {
         let predicate = MethodPredicate::new(config);
 
         // Test matching methods
-        let request = create_test_request(HttpMethod::Get, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", None, vec![], "http://test.co.za");
         assert!(predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Post, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Post, "/api", None, vec![], "http://test.co.za");
         assert!(predicate.matches(&request).await);
 
         // Test non-matching methods
-        let request = create_test_request(HttpMethod::Put, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Put, "/api", None, vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Delete, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Delete, "/api", None, vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
     }
 
@@ -86,7 +87,7 @@ mod tests {
     async fn test_header_predicate() {
         let mut headers = HashMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
-        
+
         let config = HeaderPredicateConfig {
             headers,
             exact_match: true,
@@ -99,6 +100,7 @@ mod tests {
             "/api",
             None,
             vec![("content-type", "application/json")],
+            "http://test.co.za",
         );
         assert!(predicate.matches(&request).await);
 
@@ -108,10 +110,11 @@ mod tests {
             "/api",
             None,
             vec![("content-type", "text/plain")],
+            "http://test.co.za",
         );
         assert!(!predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Get, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", None, vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
     }
 
@@ -119,7 +122,7 @@ mod tests {
     async fn test_query_predicate() {
         let mut params = HashMap::new();
         params.insert("version".to_string(), "v1".to_string());
-        
+
         let config = QueryPredicateConfig {
             params,
             exact_match: true,
@@ -127,17 +130,17 @@ mod tests {
         let predicate = QueryPredicate::new(config);
 
         // Test matching query parameters
-        let request = create_test_request(HttpMethod::Get, "/api", Some("version=v1"), vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", Some("version=v1"), vec![], "http://test.co.za");
         assert!(predicate.matches(&request).await);
 
         // Test non-matching query parameters
-        let request = create_test_request(HttpMethod::Get, "/api", Some("version=v2"), vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", Some("version=v2"), vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Get, "/api", Some("other=value"), vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", Some("other=value"), vec![], "http://test.co.za");
         assert!(!predicate.matches(&request).await);
 
-        let request = create_test_request(HttpMethod::Get, "/api", None, vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api", None, vec![],"http://test.co.za");
         assert!(!predicate.matches(&request).await);
     }
 }

--- a/src/router/tests.rs
+++ b/src/router/tests.rs
@@ -35,7 +35,7 @@ mod tests {
             headers: header_map,
             body: Body::from(Vec::new()),
             context: Arc::new(RwLock::new(RequestContext::default())),
-            target: target.to_string(),
+            custom_target: target.to_string(),
         }
     }
 

--- a/src/router/tests.rs
+++ b/src/router/tests.rs
@@ -35,7 +35,7 @@ mod tests {
             headers: header_map,
             body: Body::from(Vec::new()),
             context: Arc::new(RwLock::new(RequestContext::default())),
-            custom_target: target.to_string(),
+            custom_target: Some(target.to_string()),
         }
     }
 

--- a/src/security/tests.rs
+++ b/src/security/tests.rs
@@ -31,7 +31,7 @@ mod tests {
             headers: header_map,
             body: Body::from(Vec::new()),
             context: Arc::new(RwLock::new(RequestContext::default())),
-            target: target.to_string(),
+            custom_target: target.to_string(),
         }
     }
 

--- a/src/security/tests.rs
+++ b/src/security/tests.rs
@@ -31,7 +31,7 @@ mod tests {
             headers: header_map,
             body: Body::from(Vec::new()),
             context: Arc::new(RwLock::new(RequestContext::default())),
-            custom_target: target.to_string(),
+            custom_target: Some(target.to_string()),
         }
     }
 

--- a/src/security/tests.rs
+++ b/src/security/tests.rs
@@ -15,7 +15,7 @@ mod tests {
     use tokio::sync::RwLock;
 
     // Helper function to create a test request
-    fn create_test_request(method: HttpMethod, path: &str, headers: Vec<(&'static str, &'static str)>) -> ProxyRequest {
+    fn create_test_request(method: HttpMethod, path: &str, headers: Vec<(&'static str, &'static str)>, target: &str) -> ProxyRequest {
         let mut header_map = reqwest::header::HeaderMap::new();
         for (name, value) in headers {
             header_map.insert(
@@ -31,6 +31,7 @@ mod tests {
             headers: header_map,
             body: Body::from(Vec::new()),
             context: Arc::new(RwLock::new(RequestContext::default())),
+            target: target.to_string(),
         }
     }
 
@@ -38,27 +39,27 @@ mod tests {
     async fn test_security_chain_bypass_routes() {
         // Create a security chain with a mock provider
         let mut chain = SecurityChain::new(vec!["/health".to_string(), "/public/".to_string()]);
-        
+
         // Add a mock provider
         let mock_provider = MockSecurityProvider::new();
-        
+
         chain.add(Arc::new(mock_provider));
-        
+
         // Test bypass routes
-        let request = create_test_request(HttpMethod::Get, "/health", vec![]);
+        let request = create_test_request(HttpMethod::Get, "/health", vec![], "http://test.co.za");
         let result = chain.apply_pre(request).await;
         assert!(result.is_ok());
-        
-        let request = create_test_request(HttpMethod::Post, "/health", vec![]);
+
+        let request = create_test_request(HttpMethod::Post, "/health", vec![], "http://test.co.za");
         let result = chain.apply_pre(request).await;
         assert!(result.is_ok());
-        
-        let request = create_test_request(HttpMethod::Get, "/public/docs", vec![]);
+
+        let request = create_test_request(HttpMethod::Get, "/public/docs", vec![], "http://test.co.za");
         let result = chain.apply_pre(request).await;
         assert!(result.is_ok());
-        
+
         // Test non-bypass route
-        let request = create_test_request(HttpMethod::Get, "/api/users", vec![]);
+        let request = create_test_request(HttpMethod::Get, "/api/users", vec![], "http://test.co.za");
         let result = chain.apply_pre(request).await;
         assert!(result.is_err());
     }
@@ -66,23 +67,23 @@ mod tests {
     // Mock implementations for testing
     #[derive(Debug)]
     struct MockSecurityProvider {}
-    
+
     impl MockSecurityProvider {
         fn new() -> Self {
             Self {}
         }
     }
-    
+
     #[async_trait]
     impl SecurityProvider for MockSecurityProvider {
         fn stage(&self) -> SecurityStage {
             SecurityStage::Both
         }
-        
+
         fn name(&self) -> &str {
             "mock-provider"
         }
-        
+
         async fn pre(&self, request: ProxyRequest) -> Result<ProxyRequest, ProxyError> {
             // This mock always fails authentication unless bypassed
             Err(ProxyError::SecurityError("Mock authentication failure".to_string()))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -345,7 +345,6 @@ async fn convert_hyper_request(
     let path = uri.path().to_owned();
     let query = uri.query().map(|q| q.to_owned());
     let headers = req.headers().clone();
-    let custom_target = String::from("");
 
     crate::trace!("Converting request: {} {} with {} headers", 
         method, path, headers.len());
@@ -366,7 +365,7 @@ async fn convert_hyper_request(
             start_time: Some(std::time::Instant::now()),
             attributes: std::collections::HashMap::new(),
         })),
-        custom_target,
+        custom_target: None,
     })
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -345,7 +345,7 @@ async fn convert_hyper_request(
     let path = uri.path().to_owned();
     let query = uri.query().map(|q| q.to_owned());
     let headers = req.headers().clone();
-    let target = uri.clone().to_string();
+    let custom_target = String::from("");
 
     crate::trace!("Converting request: {} {} with {} headers", 
         method, path, headers.len());
@@ -366,7 +366,7 @@ async fn convert_hyper_request(
             start_time: Some(std::time::Instant::now()),
             attributes: std::collections::HashMap::new(),
         })),
-        target,
+        custom_target,
     })
 }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -42,10 +42,10 @@ mod tests {
             .header("content-type", "application/json")
             .body(Full::new(Bytes::from(r#"{"result":"success"}"#)))
             .unwrap();
-        
+
         // Convert to proxy response
         let proxy_response = convert_hyper_response(hyper_response);
-        
+
         // Verify the conversion
         assert_eq!(proxy_response.status, 200);
         assert!(proxy_response.headers.contains_key("content-type"));


### PR DESCRIPTION
This adds the ability for filters to dynamically set a custom target for a request in cases where it may be required. If no custom target gets specified, then the configured target will be used as the default (which is the current functionality).