### PR TITLE
OIDC: bearer token fix (ensuring token case sensitivity is maintained)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "foxy-io"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foxy-io"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2024"
 authors = ["Johan Steffens <johan@steff.co.za>"]
 description = "A configuration-driven and hyper-extensible HTTP proxy library"

--- a/src/security/oidc.rs
+++ b/src/security/oidc.rs
@@ -635,7 +635,6 @@ impl OidcProvider {
             req.path
         );
 
-        // 1) Extract bearer token
         let auth_header = if let Some(h) = req.headers.get("authorization") {
             match h.to_str() {
                 Ok(s) => s,
@@ -693,6 +692,7 @@ impl SecurityProvider for OidcProvider {
             return Ok(req);
         }
 
+        // 1) Extract bearer token
         let token = match self.extract_bearer_token(&req) {
             Ok(value) => value,
             Err(value) => return Err(value),

--- a/src/security/oidc.rs
+++ b/src/security/oidc.rs
@@ -623,6 +623,52 @@ impl OidcProvider {
         }
         bypassed
     }
+
+    pub(crate) fn extract_bearer_token<'a>(
+        &self,
+        req: &'a ProxyRequest,
+    ) -> Result<&'a str, ProxyError> {
+        debug_fmt!(
+            "OidcProvider",
+            "OIDC validating request: {} {}",
+            req.method,
+            req.path
+        );
+
+        // 1) Extract bearer token
+        let auth_header = if let Some(h) = req.headers.get("authorization") {
+            match h.to_str() {
+                Ok(s) => s,
+                Err(e) => {
+                    let err =
+                        ProxyError::SecurityError(format!("Invalid authorization header: {e}"));
+                    warn_fmt!("OidcProvider", "{}", err);
+                    return Err(err);
+                }
+            }
+        } else {
+            let err = ProxyError::SecurityError("Missing authorization header".to_string());
+            warn_fmt!("OidcProvider", "{}", err);
+            return Err(err);
+        };
+
+        if !auth_header.to_lowercase().starts_with(BEARER) {
+            let err = ProxyError::SecurityError(format!(
+                "Invalid authorization scheme: expected 'Bearer', got '{}'",
+                auth_header.split_whitespace().next().unwrap_or("")
+            ));
+            warn_fmt!("OidcProvider", "{}", err);
+            return Err(err);
+        }
+
+        let token = &auth_header[BEARER.len()..];
+        if token.is_empty() {
+            let err = ProxyError::SecurityError("Empty bearer token".to_string());
+            warn_fmt!("OidcProvider", "{}", err);
+            return Err(err);
+        }
+        Ok(token)
+    }
 }
 
 #[async_trait]
@@ -647,45 +693,10 @@ impl SecurityProvider for OidcProvider {
             return Ok(req);
         }
 
-        debug_fmt!(
-            "OidcProvider",
-            "OIDC validating request: {} {}",
-            req.method,
-            req.path
-        );
-
-        // 1) Extract bearer token
-        let auth_header = if let Some(h) = req.headers.get("authorization") {
-            match h.to_str() {
-                Ok(s) => s.to_lowercase(),
-                Err(e) => {
-                    let err =
-                        ProxyError::SecurityError(format!("Invalid authorization header: {e}"));
-                    warn_fmt!("OidcProvider", "{}", err);
-                    return Err(err);
-                }
-            }
-        } else {
-            let err = ProxyError::SecurityError("Missing authorization header".to_string());
-            warn_fmt!("OidcProvider", "{}", err);
-            return Err(err);
+        let token = match self.extract_bearer_token(&req) {
+            Ok(value) => value,
+            Err(value) => return Err(value),
         };
-
-        if !auth_header.starts_with(BEARER) {
-            let err = ProxyError::SecurityError(format!(
-                "Invalid authorization scheme: expected 'Bearer', got '{}'",
-                auth_header.split_whitespace().next().unwrap_or("")
-            ));
-            warn_fmt!("OidcProvider", "{}", err);
-            return Err(err);
-        }
-
-        let token = &auth_header[BEARER.len()..];
-        if token.is_empty() {
-            let err = ProxyError::SecurityError("Empty bearer token".to_string());
-            warn_fmt!("OidcProvider", "{}", err);
-            return Err(err);
-        }
 
         // 2) Validate the token
         trace_fmt!("OidcProvider", "Validating token: {}", token);


### PR DESCRIPTION
The following change addresses a bug where for oidc previously the bearer token wasnt able to decode properly since its case was changed. The current fix compensates for that by keeping the token value as is, and able to decode